### PR TITLE
sacrificing a tiny bit of correctness for a boost in performances

### DIFF
--- a/frontend/src/main/scala/game/GameStateManager.scala
+++ b/frontend/src/main/scala/game/GameStateManager.scala
@@ -33,6 +33,8 @@ import scala.Ordering.Double.TotalOrdering
 import scala.scalajs.js.timers.setTimeout
 import game.ui.effects.errormessages.ErrorMessagesManager
 import scala.concurrent.duration._
+import gamelogic.gamestate.GreedyActionGatherer
+import gamelogic.gamestate.ActionGatherer
 
 final class GameStateManager(
     reactiveStage: ReactiveStage,
@@ -67,8 +69,7 @@ final class GameStateManager(
 
   def serverTime: Long = System.currentTimeMillis() + deltaTimeWithServer
 
-  private var actionCollector =
-    ImmutableActionCollector(initialGameState, timeBetweenGameStates = 300, timeToOldestGameState = 20000)
+  private var actionCollector: ActionGatherer = new GreedyActionGatherer(initialGameState)
   private val gameDrawer = new GameDrawer(
     reactiveStage,
     resources,

--- a/game-server/src/main/scala/game/GameMaster.scala
+++ b/game-server/src/main/scala/game/GameMaster.scala
@@ -16,6 +16,7 @@ import zio.ZIO
 import zio.duration.Duration.fromScala
 
 import scala.concurrent.duration._
+import gamelogic.gamestate.GreedyActionGatherer
 
 object GameMaster {
 
@@ -204,7 +205,7 @@ object GameMaster {
   }
 
   /** In millis */
-  final val gameLoopTiming = 1000L / 10L
+  final val gameLoopTiming = 1000L / 30L
 
   private def preGameBehaviour(
       pendingActions: List[GameAction],
@@ -417,7 +418,7 @@ object GameMaster {
                 context.self ! MultipleActionsWrapper(maybePreGameActions.get)
                 context.self ! GameLoop
 
-                val actionCollector = ImmutableActionCollector(GameState.empty)
+                val actionCollector = new GreedyActionGatherer(GameState.empty)
                 preGameBehaviour(
                   Nil,
                   actionUpdateCollector,

--- a/shared/src/main/scala/gamelogic/gamestate/ActionGatherer.scala
+++ b/shared/src/main/scala/gamelogic/gamestate/ActionGatherer.scala
@@ -34,4 +34,6 @@ trait ActionGatherer {
     */
   def masterAddAndRemoveActions(actionsToAdd: List[GameAction]): (ActionGatherer, Long, List[GameAction.Id])
 
+  protected final def shouldKeepAction(action: GameAction, state: GameState): Boolean = state.isLegalAction(action)
+
 }

--- a/shared/src/main/scala/gamelogic/gamestate/GameState.scala
+++ b/shared/src/main/scala/gamelogic/gamestate/GameState.scala
@@ -41,7 +41,7 @@ final class GameState(
 ) {
 
   def copy(
-      time: Long                                              = time,
+      newTime: Long                                           = time,
       startTime: Option[Long]                                 = startTime,
       endTime: Option[Long]                                   = endTime,
       castingEntityInfo: Map[Entity.Id, EntityCastingInfo]    = castingEntityInfo,
@@ -50,7 +50,7 @@ final class GameState(
       entities: Map[Entity.Id, Entity]                        = entities,
       markersInfo: Map[GameMarker, GameMarkerInfo]            = markersInfo
   ): GameState = new GameState(
-    time,
+    time max newTime,
     startTime,
     endTime,
     castingEntityInfo,
@@ -203,9 +203,9 @@ final class GameState(
     * a simple Map in the future. Perhaps something like a QuadTree would be better for performances.
     */
   def withObstacle(obstacle: Obstacle): GameState =
-    copy(time = obstacle.time, entities = entities + (obstacle.id -> obstacle))
-  def removeObstacle(obstacleId: Entity.Id, time: Long): GameState =
-    copy(entities = entities - obstacleId, time = time)
+    copy(newTime = obstacle.time max time, entities = entities + (obstacle.id -> obstacle))
+  def removeObstacle(obstacleId: Entity.Id, newTime: Long): GameState =
+    copy(entities = entities - obstacleId, newTime = time max newTime)
 
   /**
     * Adds the information about the given [[GameMarker]].

--- a/shared/src/main/scala/gamelogic/gamestate/GreedyActionGatherer.scala
+++ b/shared/src/main/scala/gamelogic/gamestate/GreedyActionGatherer.scala
@@ -1,0 +1,24 @@
+package gamelogic.gamestate
+
+final class GreedyActionGatherer(val currentGameState: GameState) extends ActionGatherer {
+
+  def slaveAddAndRemoveActions(
+      actionsToAdd: List[GameAction],
+      oldestTimeToRemove: Long,
+      idsOfActionsToRemove: List[GameAction.Id]
+  ): GreedyActionGatherer =
+    new GreedyActionGatherer(
+      currentGameState.applyActions(actionsToAdd.filterNot(action => idsOfActionsToRemove.contains(action.id)))
+    )
+
+  def masterAddAndRemoveActions(actionsToAdd: List[GameAction]): (GreedyActionGatherer, Long, List[GameAction.Id]) = {
+    val (newGameState, idsToRemove) = actionsToAdd.foldLeft((currentGameState, List.empty[GameAction.Id])) {
+      case ((gameState, idsToRemove), action) =>
+        if (shouldKeepAction(action, gameState)) (action(gameState), idsToRemove)
+        else (gameState, action.id +: idsToRemove)
+    }
+
+    (new GreedyActionGatherer(newGameState), 0L, idsToRemove)
+  }
+
+}

--- a/shared/src/main/scala/gamelogic/gamestate/statetransformers/CasterUsesAbility.scala
+++ b/shared/src/main/scala/gamelogic/gamestate/statetransformers/CasterUsesAbility.scala
@@ -11,7 +11,7 @@ final class CasterUsesAbility(ability: Ability) extends GameStateTransformer {
         gameState
       } { entity =>
         gameState.copy(
-          time              = ability.time,
+          newTime           = ability.time,
           castingEntityInfo = gameState.castingEntityInfo - entity.id,
           entities          = gameState.entities + (entity.id -> entity.useAbility(ability))
         )

--- a/shared/src/main/scala/gamelogic/gamestate/statetransformers/EdgeGameTransformer.scala
+++ b/shared/src/main/scala/gamelogic/gamestate/statetransformers/EdgeGameTransformer.scala
@@ -5,8 +5,8 @@ import gamelogic.gamestate.statetransformers.EdgeGameTransformer.EdgeType
 
 final class EdgeGameTransformer(time: Long, edgeType: EdgeType) extends GameStateTransformer {
   def apply(v1: GameState): GameState = edgeType match {
-    case EdgeType.Beginning => v1.copy(time = time, startTime = Some(time))
-    case EdgeType.Ending    => v1.copy(time = time, endTime   = Some(time))
+    case EdgeType.Beginning => v1.copy(newTime = time, startTime = Some(time))
+    case EdgeType.Ending    => v1.copy(newTime = time, endTime   = Some(time))
   }
 }
 

--- a/shared/src/main/scala/gamelogic/gamestate/statetransformers/EntityStartsCastingTransformer.scala
+++ b/shared/src/main/scala/gamelogic/gamestate/statetransformers/EntityStartsCastingTransformer.scala
@@ -7,7 +7,7 @@ import gamelogic.gamestate.GameState
 final class EntityStartsCastingTransformer(entityCastingInfo: EntityCastingInfo) extends GameStateTransformer {
   def apply(gameState: GameState): GameState =
     gameState.copy(
-      time              = entityCastingInfo.startedTime,
+      newTime           = entityCastingInfo.startedTime,
       castingEntityInfo = gameState.castingEntityInfo + (entityCastingInfo.casterId -> entityCastingInfo)
     )
 }

--- a/shared/src/main/scala/gamelogic/gamestate/statetransformers/RemoveBuffTransformer.scala
+++ b/shared/src/main/scala/gamelogic/gamestate/statetransformers/RemoveBuffTransformer.scala
@@ -13,15 +13,15 @@ final class RemoveBuffTransformer(time: Long, bearerId: Entity.Id, buffId: Buff.
       case Some(_: TickerBuff) =>
         val newBearerBuffs = gameState.tickerBuffs.get(bearerId).map(_ - buffId).getOrElse(Map())
         if (newBearerBuffs.isEmpty)
-          gameState.copy(time = time, tickerBuffs = gameState.tickerBuffs - bearerId)
+          gameState.copy(newTime = time, tickerBuffs = gameState.tickerBuffs - bearerId)
         else
-          gameState.copy(time = time, tickerBuffs = gameState.tickerBuffs + (bearerId -> newBearerBuffs))
+          gameState.copy(newTime = time, tickerBuffs = gameState.tickerBuffs + (bearerId -> newBearerBuffs))
       case Some(_: PassiveBuff) =>
         val newBearerBuffs = gameState.passiveBuffs.get(bearerId).map(_ - buffId).getOrElse(Map())
         if (newBearerBuffs.isEmpty)
-          gameState.copy(time = time, passiveBuffs = gameState.passiveBuffs - bearerId)
+          gameState.copy(newTime = time, passiveBuffs = gameState.passiveBuffs - bearerId)
         else
-          gameState.copy(time = time, passiveBuffs = gameState.passiveBuffs + (bearerId -> newBearerBuffs))
+          gameState.copy(newTime = time, passiveBuffs = gameState.passiveBuffs + (bearerId -> newBearerBuffs))
       case None => gameState
       case Some(buff) =>
         println("wtf!?")

--- a/shared/src/main/scala/gamelogic/gamestate/statetransformers/RemoveEntityTransformer.scala
+++ b/shared/src/main/scala/gamelogic/gamestate/statetransformers/RemoveEntityTransformer.scala
@@ -5,5 +5,5 @@ import gamelogic.gamestate.GameState
 
 final class RemoveEntityTransformer(entityId: Entity.Id, time: Long) extends GameStateTransformer {
   def apply(gameState: GameState): GameState =
-    gameState.copy(time = time, entities = gameState.entities - entityId)
+    gameState.copy(newTime = time, entities = gameState.entities - entityId)
 }

--- a/shared/src/main/scala/gamelogic/gamestate/statetransformers/UpdateTimeTransformer.scala
+++ b/shared/src/main/scala/gamelogic/gamestate/statetransformers/UpdateTimeTransformer.scala
@@ -6,5 +6,5 @@ import gamelogic.gamestate.GameState
   * Modifies the time of the [[gamelogic.gamestate.GameState]], leaving all other properties untouched.
   */
 final class UpdateTimeTransformer(newTime: Long) extends GameStateTransformer {
-  def apply(gameState: GameState): GameState = gameState.copy(time = newTime)
+  def apply(gameState: GameState): GameState = gameState.copy(newTime = newTime)
 }

--- a/shared/src/main/scala/gamelogic/gamestate/statetransformers/WithBuff.scala
+++ b/shared/src/main/scala/gamelogic/gamestate/statetransformers/WithBuff.scala
@@ -8,14 +8,14 @@ final class WithBuff(buff: Buff) extends GameStateTransformer {
     case buff: TickerBuff =>
       val newBuffMap = gameState.tickerBuffs.getOrElse(buff.bearerId, Map())
       gameState.copy(
-        time        = buff.appearanceTime,
+        newTime     = buff.appearanceTime,
         tickerBuffs = gameState.tickerBuffs + (buff.bearerId -> (newBuffMap + (buff.buffId -> buff)))
       )
 
     case buff: PassiveBuff =>
       val newBuffMap = gameState.passiveBuffs.getOrElse(buff.bearerId, Map())
       gameState.copy(
-        time         = buff.appearanceTime,
+        newTime      = buff.appearanceTime,
         passiveBuffs = gameState.passiveBuffs + (buff.bearerId -> (newBuffMap + (buff.buffId -> buff)))
       )
   }

--- a/shared/src/main/scala/gamelogic/gamestate/statetransformers/WithEntity.scala
+++ b/shared/src/main/scala/gamelogic/gamestate/statetransformers/WithEntity.scala
@@ -5,5 +5,5 @@ import gamelogic.gamestate.GameState
 
 final class WithEntity(entity: Entity, time: Long) extends GameStateTransformer {
   def apply(gameState: GameState): GameState =
-    gameState.copy(time = time, entities = gameState.entities + (entity.id -> entity))
+    gameState.copy(newTime = time, entities = gameState.entities + (entity.id -> entity))
 }

--- a/shared/src/main/scala/gamelogic/gamestate/statetransformers/WithSimpleBullet.scala
+++ b/shared/src/main/scala/gamelogic/gamestate/statetransformers/WithSimpleBullet.scala
@@ -6,7 +6,7 @@ import gamelogic.gamestate.GameState
 final class WithSimpleBullet(simpleBullet: SimpleBulletBody) extends GameStateTransformer {
   def apply(gameState: GameState): GameState =
     gameState.copy(
-      time     = simpleBullet.time,
+      newTime  = simpleBullet.time,
       entities = gameState.simpleBullets + (simpleBullet.id -> simpleBullet)
     )
 }

--- a/shared/src/test/scala/gamelogic/gamestate/gameactions/EdgeGameActionsSpecs.scala
+++ b/shared/src/test/scala/gamelogic/gamestate/gameactions/EdgeGameActionsSpecs.scala
@@ -12,7 +12,7 @@ object EdgeGameActionsSpecs extends DefaultRunnableSpec {
     testM("Game must be started after GameStart action") {
       checkM(Gen.long(0, Long.MaxValue), Gen.long(0, Long.MaxValue)) { (time, startingTime) =>
         val gameStart = GameStart(0, startingTime)
-        val gameState = GameState.empty.copy(time = time)
+        val gameState = GameState.empty.copy(newTime = time)
         assertM(UIO(gameStart(gameState).started))(equalTo(true))
       }
     },
@@ -25,7 +25,7 @@ object EdgeGameActionsSpecs extends DefaultRunnableSpec {
     testM("Applying a time update on a game state changes its time") {
       checkM(Gen.anyLong, Gen.anyLong) { (time, updateTime) =>
         val updateTimestamp = UpdateTimestamp(0, updateTime)
-        val gameState       = GameState.empty.copy(time = time)
+        val gameState       = GameState.empty.copy(newTime = time)
         assertM(UIO(updateTimestamp(gameState).time))(equalTo(updateTime))
       }
     }

--- a/shared/src/test/scala/gamelogic/gamestate/gameactions/ImmutableActionCollectorSpecs.scala
+++ b/shared/src/test/scala/gamelogic/gamestate/gameactions/ImmutableActionCollectorSpecs.scala
@@ -20,10 +20,10 @@ object ImmutableActionCollectorSpecs extends DefaultRunnableSpec {
       val (afterGameStart, _, _) = collector.masterAddAndRemoveActions(List(gameStart))
 
       for {
-        gameIsStarted <- assertM(UIO(afterGameStart.currentGameState.started))(equalTo(true))
-        thereAreActions <- assertM(UIO(afterGameStart.actionsAndStates.nonEmpty))(equalTo(true))
+        gameIsStarted          <- assertM(UIO(afterGameStart.currentGameState.started))(equalTo(true))
+        thereAreActions        <- assertM(UIO(afterGameStart.actionsAndStates.nonEmpty))(equalTo(true))
         gameStartActionIsThere <- assertM(UIO(afterGameStart.actionsAndStates.head._2))(equalTo(List(gameStart)))
-        t <- ZIO.effectTotal(afterGameStart.masterAddAndRemoveActions(List(endGame)))
+        t                      <- ZIO.effectTotal(afterGameStart.masterAddAndRemoveActions(List(endGame)))
         (afterGameEnds, _, _) = t
         gameHasEnded <- assertM(UIO(afterGameEnds.currentGameState.ended))(equalTo(true))
       } yield gameIsStarted && thereAreActions && gameStartActionIsThere && gameHasEnded
@@ -49,11 +49,11 @@ object ImmutableActionCollectorSpecs extends DefaultRunnableSpec {
       val secondPlayer = AddPlayerByClass(1L, 2L, 1L, Complex.i, PlayerClasses.Hexagon, 2, "hexagon")
 
       for {
-        afterGameStart <- UIO(collector.masterAddAndRemoveActions(gameStart :: Nil)).map(_._1)
-        afterFirstPlayer <- UIO(afterGameStart.masterAddAndRemoveActions(firstPlayer :: Nil)).map(_._1)
+        afterGameStart    <- UIO(collector.masterAddAndRemoveActions(gameStart :: Nil)).map(_._1)
+        afterFirstPlayer  <- UIO(afterGameStart.masterAddAndRemoveActions(firstPlayer :: Nil)).map(_._1)
         afterSecondPlayer <- UIO(afterFirstPlayer.masterAddAndRemoveActions(secondPlayer :: Nil)).map(_._1)
-        actionsInOrder <- UIO(afterSecondPlayer.actionsAndStates.head._2)
-        result <- assertM(UIO(actionsInOrder))(equalTo(List[GameAction](gameStart, secondPlayer, firstPlayer)))
+        actionsInOrder    <- UIO(afterSecondPlayer.actionsAndStates.head._2)
+        result            <- assertM(UIO(actionsInOrder))(equalTo(List[GameAction](gameStart, secondPlayer, firstPlayer)))
       } yield result
     },
     testM("Adding two players makes gameState with two players") {
@@ -63,9 +63,9 @@ object ImmutableActionCollectorSpecs extends DefaultRunnableSpec {
       val secondPlayer = AddPlayerByClass(1L, 2L, 1L, Complex.i, PlayerClasses.Hexagon, 2, "hexagon")
 
       for {
-        afterGameStart <- UIO(collector.masterAddAndRemoveActions(gameStart :: Nil)).map(_._1)
-        afterFirstPlayer <- UIO(afterGameStart.masterAddAndRemoveActions(firstPlayer :: Nil)).map(_._1)
-        firstPlayerCheck <- assertM(UIO(afterFirstPlayer.currentGameState.players.size))(equalTo(1))
+        afterGameStart    <- UIO(collector.masterAddAndRemoveActions(gameStart :: Nil)).map(_._1)
+        afterFirstPlayer  <- UIO(afterGameStart.masterAddAndRemoveActions(firstPlayer :: Nil)).map(_._1)
+        firstPlayerCheck  <- assertM(UIO(afterFirstPlayer.currentGameState.players.size))(equalTo(1))
         afterSecondPlayer <- UIO(afterFirstPlayer.masterAddAndRemoveActions(secondPlayer :: Nil)).map(_._1)
         secondPlayerCheck <- assertM(UIO(afterSecondPlayer.currentGameState.players.size))(equalTo(2))
       } yield firstPlayerCheck && secondPlayerCheck
@@ -80,11 +80,11 @@ object ImmutableActionCollectorSpecs extends DefaultRunnableSpec {
 
       for {
         withActions <- UIO { collector.masterAddAndRemoveActions(actions) }.map(_._1)
-        result <- assertM(UIO(withActions.currentGameState.players.keys.toList.sorted))(equalTo(List(0L, 1L)))
+        result      <- assertM(UIO(withActions.currentGameState.players.keys.toList.sorted))(equalTo(List(0L, 1L)))
       } yield result
     },
     testM("Actions separated by more than the limit") {
-      val collector = ImmutableActionCollector(GameState.empty, timeBetweenGameStates = 3L)
+      val collector = ImmutableActionCollector(GameState.empty, numberOfActionsBetweenGameStates = 2)
       val someDummyUpdates = (0 until 10).map(_.toLong).map { idx =>
         UpdateTimestamp(idx, idx * 4)
       }
@@ -96,11 +96,11 @@ object ImmutableActionCollectorSpecs extends DefaultRunnableSpec {
         afterDummies <- UIO(someDummyUpdates.foldLeft(collector) { (newCollector, action) =>
           newCollector.masterAddAndRemoveActions(action :: Nil)._1
         })
-        afterGameStart <- UIO(afterDummies.masterAddAndRemoveActions(gameStart :: Nil)).map(_._1)
+        afterGameStart    <- UIO(afterDummies.masterAddAndRemoveActions(gameStart :: Nil)).map(_._1)
         afterSecondPlayer <- UIO(afterGameStart.masterAddAndRemoveActions(secondPlayer :: Nil)).map(_._1)
-        afterFirstPlayer <- UIO(afterSecondPlayer.masterAddAndRemoveActions(firstPlayer :: Nil)).map(_._1)
-        actionsInOrder <- UIO(afterFirstPlayer.actionsAndStates.head._2)
-        result <- assertM(UIO(actionsInOrder))(equalTo(List(firstPlayer))) // only first player should be there
+        afterFirstPlayer  <- UIO(afterSecondPlayer.masterAddAndRemoveActions(firstPlayer :: Nil)).map(_._1)
+        actionsInOrder    <- UIO(afterFirstPlayer.actionsAndStates.head._2)
+        result            <- assertM(UIO(actionsInOrder))(equalTo(List(firstPlayer))) // only first player should be there
       } yield result
     },
     testM("Adding one player and starting game together") {


### PR DESCRIPTION
We replaced the previous `ImmutableActionCollector` by a more naive (but also much more performant) implementation, called `GreedyActionGatherer`. 
Instead of inserting actions exactly where they are in the timeline, we insert them on the top of the game action stacks. This results in a lot less re-computation of game states, which in turn induces a massive performance boost.